### PR TITLE
Fix: Correct syntax error in MyHabitsScreen

### DIFF
--- a/habit_stacker/lib/presentation/screens/my_habits/my_habits_screen.dart
+++ b/habit_stacker/lib/presentation/screens/my_habits/my_habits_screen.dart
@@ -141,30 +141,37 @@ class _HabitPageViewState extends State<HabitPageView> {
                   child: Column(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                    if (habit.dailyRoutine != null) ...[
-                      Text(
-                        '${habit.stackingOrder} in ${habit.dailyRoutine!.name}',
-                        style: Theme.of(context).textTheme.titleMedium,
+                      if (habit.dailyRoutine != null) ...[
+                        Text(
+                          '${habit.stackingOrder} in ${habit.dailyRoutine!.name}',
+                          style: Theme.of(context).textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 8),
+                      ],
+                      Text(habit.name,
+                          style: Theme.of(context).textTheme.headlineMedium),
+                      const SizedBox(height: 16),
+                      Text('Reward: ${habit.reward}'),
+                      const SizedBox(height: 32),
+                      ElevatedButton(
+                        key: Key('completeHabitButton_${habit.id}'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor:
+                              habit.isCompletedToday ? Colors.green : null,
+                        ),
+                        onPressed: () {
+                          context
+                              .read<HabitBloc>()
+                              .add(HabitCompletionToggled(habit));
+                        },
+                        child: Text(habit.isCompletedToday
+                            ? 'Completed!'
+                            : 'Complete Habit'),
                       ),
-                      const SizedBox(height: 8),
                     ],
-                    Text(habit.name, style: Theme.of(context).textTheme.headlineMedium),
-                    const SizedBox(height: 16),
-                    Text('Reward: ${habit.reward}'),
-                    const SizedBox(height: 32),
-                    ElevatedButton(
-                      key: Key('completeHabitButton_${habit.id}'),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: habit.isCompletedToday ? Colors.green : null,
-                      ),
-                      onPressed: () {
-                        context.read<HabitBloc>().add(HabitCompletionToggled(habit));
-                      },
-                      child: Text(habit.isCompletedToday ? 'Completed!' : 'Complete Habit'),
-                    ),
-                  ],
+                  ),
                 ),
-              );
+              ),
             },
           ),
         ),


### PR DESCRIPTION
Resolves a build failure caused by a missing closing parenthesis in the `my_habits_screen.dart` file. The widget tree within the `PageView.builder` was not correctly closed, leading to a syntax error.

The patch corrects the placement of the closing parenthesis to ensure the `Card` and `InkWell` widgets are properly structured.