### PR TITLE
Fix: Correct syntax error in MyHabitsScreen

### DIFF
--- a/habit_stacker/lib/presentation/screens/my_habits/my_habits_screen.dart
+++ b/habit_stacker/lib/presentation/screens/my_habits/my_habits_screen.dart
@@ -171,7 +171,7 @@ class _HabitPageViewState extends State<HabitPageView> {
                     ],
                   ),
                 ),
-              ),
+              );
             },
           ),
         ),


### PR DESCRIPTION
Resolves a build failure caused by a missing closing parenthesis in the `my_habits_screen.dart` file. The widget tree within the `PageView.builder` was not correctly closed, leading to a syntax error.

The patch corrects the placement of the closing parenthesis to ensure the `Card` and `InkWell` widgets are properly structured.